### PR TITLE
If no parameters passed return empty array rather than null

### DIFF
--- a/src/Http/Controllers/EmbedController.php
+++ b/src/Http/Controllers/EmbedController.php
@@ -13,7 +13,7 @@ class EmbedController
     {
         $components = collect($request->json('components', []))->mapWithKeys(function ($component) {
             $componentName = $component['name'];
-            $componentParams = json_decode($component['params'], true);
+            $componentParams = json_decode($component['params'], true) ?? [];
 
             if (WireExtender::isEmbeddable($componentName) === false) {
                 return [$componentName => null];


### PR DESCRIPTION
fixes #8 

If no parameters are passed when using Livewire then a null parameter is passed to `Livewire\Features\SupportNestingComponents` throwing a type error.

This PR checks $componentParams and returns an empty array if null.