### PR TITLE
Add session support

### DIFF
--- a/js/wire-extender.js
+++ b/js/wire-extender.js
@@ -72,6 +72,7 @@ async function startLivewire(assets)
 {
     Livewire.hook('request', ({ options }) => {
         options.headers['X-Wire-Extender'] = '';
+        options.credentials = 'include';
     })
     await Livewire.triggerAsync('payload.intercept', {assets: componentAssets});
     Livewire.start();
@@ -88,7 +89,8 @@ function renderComponents(components)
         },
         body: JSON.stringify({
             components: components
-        })
+        }),
+       'credentials': 'include'
     })
         .then(response => response.json())
         .then(data => {

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,4 +2,4 @@
 
 use WireElements\WireExtender\Http\Controllers\EmbedController;
 
-Route::any('livewire/embed', EmbedController::class);
+Route::any('livewire/embed', EmbedController::class)->middleware('web');

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,4 +2,4 @@
 
 use WireElements\WireExtender\Http\Controllers\EmbedController;
 
-Route::any('livewire/embed', EmbedController::class)->middleware('web');
+Route::any('livewire/embed', EmbedController::class);


### PR DESCRIPTION
This PR will add support for sessions:
1. It will apply Laravel's standard `web` middleware to all incoming requests from wire extender so that Laravel will initialize a session.
2. It adds a `credentials: 'include'` option to XHR requests so that the session cookie can be stored / transferred.

Please note that it will still be required to modify some userland configuration (should be mentioned in the documentation):

**`config/cors.php`**:

```php
'paths'                => ['livewire/*'],
'allowed_methods'      => ['POST'],
'allowed_origins'      => ['https://targetdomain.test'], // List of sites that will be allowed
'supports_credentials' => true,
```

**`.env`**:
```env
SESSION_SECURE_COOKIE=true   # Add the cookie "Secure" property
SESSION_HTTP_ONLY=false      # Allows to access the cookie via JS
SESSION_SAME_SITE=none       # Sets the cookie "SameSite" property to "none"
```