### PR TITLE
Fix IgnoreForWireExtender to not mess with non Livewire requests

### DIFF
--- a/src/Http/Middlewares/IgnoreForWireExtender.php
+++ b/src/Http/Middlewares/IgnoreForWireExtender.php
@@ -20,16 +20,18 @@ trait IgnoreForWireExtender
     public function handle($request, Closure $next)
     {
         // We only care about requests from an embedded component
-        if ($this->isLivewireUpdateRequest($request)) {
-            // Loop through all components that are part of the update
-            foreach ($request->json('components', []) as $component) {
-                $snapshot = json_decode($component['snapshot'], true);
-                $component = $snapshot['memo']['name'] ?? false;
+        if (! $this->isLivewireUpdateRequest($request)) {
+            return parent::handle($request, $next);
+        }
 
-                // All components must be embeddable otherwise we will apply the existing middleware
-                if (WireExtender::isEmbeddable($component) === false) {
-                    return parent::handle($request, $next);
-                }
+        // Loop through all components that are part of the update
+        foreach ($request->json('components', []) as $component) {
+            $snapshot = json_decode($component['snapshot'], true);
+            $component = $snapshot['memo']['name'] ?? false;
+
+            // All components must be embeddable otherwise we will apply the existing middleware
+            if (WireExtender::isEmbeddable($component) === false) {
+                return parent::handle($request, $next);
             }
         }
 


### PR DESCRIPTION
Currently this trait is removing the default behavior of `VerifyCsrfToken`, as it only calls `parent::handle` if is livewire and has a component that is not embedable.

As far as i can tell we should just skip to default behavior on normal requests, right?

On my project, all other routes got affected by this trait.