### PR TITLE
[2.x] Remove Livewire v3 support

### DIFF
--- a/js/wire-extender.js
+++ b/js/wire-extender.js
@@ -66,7 +66,7 @@ function waitForLivewireAndStart() {
 }
 
 async function startLivewire(assets) {
-    Livewire.interceptRequeset(({ request }) => {
+    Livewire.interceptRequest(({ request }) => {
         request.options.headers['X-Wire-Extender'] = '1';
         request.options.credentials = 'include';
     });


### PR DESCRIPTION
Implements option 2 from the discussion in #51.

- Declare wire-extender v2 as compatible only with Livewire v4
- Remove needed for cross-version compatibility logic 